### PR TITLE
Add registered property to nat_upnp.app.src

### DIFF
--- a/src/nat_upnp.app.src
+++ b/src/nat_upnp.app.src
@@ -10,5 +10,6 @@
                   stdlib,
                   inets
                  ]},
-  {env, []}
+  {env, []},
+  {registered, []}
  ]}.


### PR DESCRIPTION
The registered property is mandatory for for systools builds.
